### PR TITLE
Prevent dismiss prop from leaking into toast DOM

### DIFF
--- a/src/components/ui/toast.jsx
+++ b/src/components/ui/toast.jsx
@@ -35,12 +35,12 @@ const toastVariants = cva(
 	},
 );
 
-const Toast = React.forwardRef(({ className, variant, ...props }, ref) => {
-	return (
-		<ToastPrimitives.Root
-			ref={ref}
-			className={cn(toastVariants({ variant }), className)}
-			{...props}
+const Toast = React.forwardRef(({ className, variant, dismiss: _dismiss, ...props }, ref) => {
+        return (
+                <ToastPrimitives.Root
+                        ref={ref}
+                        className={cn(toastVariants({ variant }), className)}
+                        {...props}
 		/>
 	);
 });

--- a/src/components/ui/toaster.jsx
+++ b/src/components/ui/toaster.jsx
@@ -14,9 +14,9 @@ export function Toaster() {
 
 	return (
 		<ToastProvider>
-			{toasts.map(({ id, title, description, action, ...props }) => {
-				return (
-					<Toast key={id} {...props}>
+                        {toasts.map(({ id, title, description, action, dismiss: _dismiss, ...props }) => {
+                                return (
+                                        <Toast key={id} {...props}>
 						<div className="grid gap-1">
 							{title && <ToastTitle>{title}</ToastTitle>}
 							{description && (


### PR DESCRIPTION
## Summary
- avoid forwarding the dismiss prop through the toast root element to stop invalid DOM attributes
- strip dismiss from toast rendering in the Toaster while keeping other toast props intact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938eec7a588832cb377e33ee5f47f5e)