### PR TITLE
Stabilize admin routing and auth handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,10 +20,7 @@ import TermsOfServicePage from '@/pages/TermsOfServicePage';
 import BrandStylePage from '@/pages/BrandStylePage';
 import AdminDashboard from '@/pages/admin/AdminDashboard';
 import AuthPage from '@/pages/AuthPage';
-import ClientBookingsView from '@/pages/admin/ClientBookingsView';
-import BookingsView from '@/pages/admin/BookingsView';
-import AdminPaymentsPage from '@/pages/admin/AdminPaymentsPage';
-import ClientPortalPage from '@/pages/ClientPortalPage.jsx'; 
+import ClientPortalPage from '@/pages/ClientPortalPage.jsx';
 import PaymentCenterPage from "@/pages/PaymentCenterPage";
 import PaymentConfirmationPage from "@/pages/PaymentConfirmationPage";
 
@@ -82,31 +79,19 @@ function AppShell() {
 
           <Route
             path="/admin/bookings"
-            element={
-              <AdminRoute>
-                <BookingsView />
-              </AdminRoute>
-            }
+            element={<Navigate to="/admin" state={{ initialView: "bookings" }} replace />}
           />
 
           <Route
             path="/admin/payments"
-            element={
-              <AdminRoute>
-                <AdminPaymentsPage />
-              </AdminRoute>
-            }
+            element={<Navigate to="/admin" state={{ initialView: "payments" }} replace />}
           />
 
           <Route path="/payment-confirmation" element={<PaymentConfirmationPage />} />
 
           <Route
             path="/admin/client-bookings"
-            element={
-              <AdminRoute>
-                <ClientBookingsView />
-              </AdminRoute>
-            }
+            element={<Navigate to="/admin" state={{ initialView: "bookings" }} replace />}
           />
 
           <Route path="/contact" element={<ContactPage />} />

--- a/src/components/auth/AdminRoute.jsx
+++ b/src/components/auth/AdminRoute.jsx
@@ -2,11 +2,7 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';
-
-const ADMIN_EMAIL = import.meta.env.VITE_ADMIN_EMAIL || 'jessabel.santos@gmail.com';
-
-// Add extra admins here (lowercase for easy matching)
-const EXTRA_ADMINS = ['sanchezservices24@yahoo.com'];
+import { buildAdminAllowlist } from '@/lib/adminAllowlist';
 
 function FullPageLoader() {
   return (
@@ -22,11 +18,7 @@ export default function AdminRoute({ children }) {
 
   if (!authReady) return <FullPageLoader />;
 
-  const allowlist = new Set([
-    (ADMIN_EMAIL || '').toLowerCase(),
-    ...EXTRA_ADMINS.map((e) => e.toLowerCase()),
-  ]);
-
+  const allowlist = buildAdminAllowlist();
   const isAdmin = !!user && !!user.email && allowlist.has(user.email.toLowerCase());
 
   if (!isAdmin) {

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -5,22 +5,15 @@ import { Button } from "@/components/ui/button";
 import { Menu, X, Phone } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import headerLogo from "@/assets/logo/logo-primary.png";
-import { useAdminAuth } from "@/pages/admin/hooks/useAdminAuth";
-
-// Hard-coded admin emails (must be lowercase)
-const ADMIN_EMAILS = [
-  "jessabel.santos@gmail.com",
-  "sanchezservices24@yahoo.com",
-];
+import { useAuth } from "@/context/AuthContext";
+import { isEmailAdmin } from "@/lib/adminAllowlist";
 
 const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
   const location = useLocation();
 
-  // We still use the hook for auth state, but we *don’t* trust its isAdmin flag
-  const { user } = useAdminAuth();
-  const emailLower = (user?.email || "").toLowerCase();
-  const showAdminLink = !!user && ADMIN_EMAILS.includes(emailLower);
+  const { user } = useAuth();
+  const showAdminLink = !!user && isEmailAdmin(user.email);
 
   const handleCallClick = () => {
     window.location.href = "tel:14016586708";

--- a/src/components/ui/toast.jsx
+++ b/src/components/ui/toast.jsx
@@ -35,12 +35,12 @@ const toastVariants = cva(
 	},
 );
 
-const Toast = React.forwardRef(({ className, variant, ...props }, ref) => {
-	return (
-		<ToastPrimitives.Root
-			ref={ref}
-			className={cn(toastVariants({ variant }), className)}
-			{...props}
+const Toast = React.forwardRef(({ className, variant, dismiss: _dismiss, ...props }, ref) => {
+        return (
+                <ToastPrimitives.Root
+                        ref={ref}
+                        className={cn(toastVariants({ variant }), className)}
+                        {...props}
 		/>
 	);
 });

--- a/src/components/ui/toaster.jsx
+++ b/src/components/ui/toaster.jsx
@@ -14,9 +14,9 @@ export function Toaster() {
 
 	return (
 		<ToastProvider>
-			{toasts.map(({ id, title, description, action, ...props }) => {
-				return (
-					<Toast key={id} {...props}>
+                        {toasts.map(({ id, title, description, action, dismiss: _dismiss, ...props }) => {
+                                return (
+                                        <Toast key={id} {...props}>
 						<div className="grid gap-1">
 							{title && <ToastTitle>{title}</ToastTitle>}
 							{description && (

--- a/src/lib/adminAllowlist.js
+++ b/src/lib/adminAllowlist.js
@@ -1,0 +1,19 @@
+// src/lib/adminAllowlist.js
+// Centralized helper to compute the admin allowlist from env vars.
+// Uses VITE_ADMIN_EMAIL (primary) and optional VITE_EXTRA_ADMINS
+// (comma-separated). All addresses are normalized to lowercase.
+
+export function buildAdminAllowlist() {
+  const primary = (import.meta.env?.VITE_ADMIN_EMAIL || "").trim().toLowerCase();
+  const extras = (import.meta.env?.VITE_EXTRA_ADMINS || "")
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+
+  return new Set([primary, ...extras].filter(Boolean));
+}
+
+export function isEmailAdmin(email) {
+  if (!email) return false;
+  return buildAdminAllowlist().has(String(email).toLowerCase());
+}

--- a/src/pages/admin/AdminDashboard.jsx
+++ b/src/pages/admin/AdminDashboard.jsx
@@ -13,6 +13,7 @@ import ReviewsView from "./ReviewsView";
 import ReportsView from "./ReportsView";
 import MaintenanceView from "./MaintenanceView";
 import ClientsView from "./ClientsView";
+import AdminPaymentsPage from "./AdminPaymentsPage";
 
 import AuthPage from "../AuthPage";
 import { AdminUIProvider } from "./context/AdminUIContext";
@@ -22,24 +23,15 @@ const AdminDashboard = ({ initialView = "dashboard" }) => {
   const location = useLocation();
 
   // If we navigated here with: navigate("/admin", { state: { activeView: "clients" } })
-// Support both patterns: activeView (old) and initialView (new)
-const forcedView =
-  location.state?.activeView ||
-  location.state?.initialView ||
-  null;
+  // Support both patterns: activeView (old) and initialView (new)
+  const forcedView =
+    location.state?.activeView || location.state?.initialView || null;
 
-const [activeView, setActiveView] = useState(
-  forcedView || initialView || "dashboard"
-);
+  const [activeView, setActiveView] = useState(
+    forcedView || initialView || "dashboard"
+  );
 
-// Sync state if navigation changes it (important for switching from Payments page)
-useEffect(() => {
-  if (forcedView && forcedView !== activeView) {
-    setActiveView(forcedView);
-  }
-}, [forcedView, activeView]);
-
-  // Keep activeView in sync if navigation state changes
+  // Sync state if navigation changes it (important for switching from Payments page)
   useEffect(() => {
     if (forcedView && forcedView !== activeView) {
       setActiveView(forcedView);
@@ -77,6 +69,13 @@ useEffect(() => {
         return <ReportsView />;
       case "maintenance":
         return <MaintenanceView />;
+      case "payments":
+        return (
+          <AdminPaymentsPage
+            embedded
+            onChangeView={setActiveView}
+          />
+        );
       default:
         return <DashboardHome onChangeView={setActiveView} />;
     }

--- a/src/pages/admin/AdminPaymentsPage.jsx
+++ b/src/pages/admin/AdminPaymentsPage.jsx
@@ -138,7 +138,7 @@ function normalizeBooking(b) {
   };
 }
 
-const AdminPaymentsPage = () => {
+const AdminPaymentsPage = ({ embedded = false, onChangeView }) => {
   const { toast } = useToast();
   const navigate = useNavigate();
   const { user, isAdmin, loading } = useAdminAuth();
@@ -840,6 +840,22 @@ const AdminPaymentsPage = () => {
     URL.revokeObjectURL(url);
   }, [rows]);
 
+  const handleViewChange = useCallback(
+    (viewId) => {
+      if (viewId === "payments") return;
+
+      if (onChangeView) {
+        onChangeView(viewId);
+        return;
+      }
+
+      navigate("/admin", {
+        state: { initialView: viewId || "dashboard" },
+      });
+    },
+    [navigate, onChangeView]
+  );
+
   // ---------- auth/layout guards ----------
   if (loading) {
     return (
@@ -855,37 +871,7 @@ const AdminPaymentsPage = () => {
     return <AuthPage />;
   }
 
-  // ---------- main admin shell ----------
-  return (
-    <AdminUIProvider>
-      <div className="min-h-screen flex bg-[#FFF7FB]">
-        <AdminSidebar
-        activeView="payments"
-        onChangeView={(viewId) => {
-            // If they click Payments again, stay on this route
-            if (viewId === "payments") {
-            navigate("/admin/payments");
-            return;
-            }
-
-            // Dashboard -> main admin shell, default view
-            if (!viewId || viewId === "dashboard") {
-            navigate("/admin", {
-                state: { initialView: "dashboard" },
-            });
-            return;
-            }
-
-            // Any other view (bookings, calendar, clients, etc.)
-            navigate("/admin", {
-            state: { initialView: viewId },
-            });
-        }}
-        />
-
-        <div className="flex-1 flex flex-col min-w-0">
-          <AdminHeader activeView="payments" user={user} />
-
+  const content = (
           <main className="flex-1 px-6 py-4 lg:px-10 lg:py-6 bg-[#FFF7FB]">
             {/* Page header */}
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-5">
@@ -1556,9 +1542,30 @@ const AdminPaymentsPage = () => {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+  );
+
+  if (embedded) {
+    return content;
+  }
+
+  // ---------- main admin shell ----------
+  return (
+    <AdminUIProvider>
+      <div className="min-h-screen flex bg-[#FFF7FB]">
+        <AdminSidebar
+          activeView="payments"
+          onChangeView={handleViewChange}
+        />
+
+        <div className="flex-1 flex flex-col min-w-0">
+          <AdminHeader activeView="payments" user={user} />
+
+          {content}
+        </div>
       </div>
     </AdminUIProvider>
   );
 };
+
 
 export default AdminPaymentsPage;

--- a/src/pages/admin/AuthPage.jsx
+++ b/src/pages/admin/AuthPage.jsx
@@ -1,5 +1,6 @@
 // pages/admin/AuthPage.jsx
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { auth } from "../../lib/firebase";
 import { upsertProfile, updateProfileLastLogin } from "@/lib/profileModel";
@@ -99,13 +100,12 @@ const AuthPage = () => {
           </button>
         </form>
 
-        <button
-          type="button"
-          onClick={() => (window.location.href = "/")}
-          className="mt-4 w-full text-center text-xs text-gray-500 hover:text-gray-700"
+        <Link
+          to="/"
+          className="mt-4 block text-center text-xs text-gray-500 hover:text-gray-700"
         >
           ← Back to website
-        </button>
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/admin/components/AdminSidebar.jsx
+++ b/src/pages/admin/components/AdminSidebar.jsx
@@ -1,7 +1,6 @@
 // src/pages/admin/components/AdminSidebar.jsx
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { useNavigate } from "react-router-dom";
 import {
   LayoutDashboard,
   CalendarDays,
@@ -25,7 +24,6 @@ const NAV_ITEMS = [
 ];
 
 export default function AdminSidebar({ activeView, onChangeView }) {
-  const navigate = useNavigate();
   return (
     <aside className="hidden lg:flex lg:flex-col w-60 bg-[#FCEFF6] border-r border-[#F3D6EA]">
       <div className="px-5 py-6 border-b border-[#F3D6EA]">
@@ -49,14 +47,7 @@ export default function AdminSidebar({ activeView, onChangeView }) {
                   ? "bg-[#F7C7E8] text-[#431039] hover:bg-[#F4B8E0]"
                   : "text-[#6B2563] hover:bg-[#FDF0F8]"
               }`}
-              onClick={() => {
-                // Payments is a separate admin route
-                if (item.id === "payments") {
-                  navigate("/admin/payments");
-                  return;
-                }
-                onChangeView(item.id);
-              }}
+              onClick={() => onChangeView(item.id)}
             >
               <Icon className="w-4 h-4" />
               {item.label}

--- a/src/pages/admin/hooks/useAdminAuth.js
+++ b/src/pages/admin/hooks/useAdminAuth.js
@@ -1,41 +1,18 @@
 // pages/admin/hooks/useAdminAuth.js
-import { useEffect, useState } from "react";
-import { onAuthStateChanged } from "firebase/auth";
-// 🔧 adjust this import if your auth lives somewhere else
-import { auth } from "../../../lib/firebase";
+import { useMemo } from "react";
+import { useAuth } from "@/context/AuthContext";
+import { buildAdminAllowlist } from "@/lib/adminAllowlist";
 
-// Optional: restrict to specific admin emails via env
-// e.g. VITE_ADMIN_EMAILS="owner@example.com,assistant@example.com"
-const ADMIN_EMAILS = (import.meta?.env?.VITE_ADMIN_EMAILS || "")
-  .split(",")
-  .map((e) => e.trim().toLowerCase())
-  .filter(Boolean);
-
+// Thin wrapper around the shared AuthContext so admin checks use the same
+// allowlist everywhere (AdminRoute, header, and admin pages).
 export function useAdminAuth() {
-  const [user, setUser] = useState(null);
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const { user, authReady } = useAuth();
 
-  useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (firebaseUser) => {
-      if (!firebaseUser) {
-        setUser(null);
-        setIsAdmin(false);
-        setLoading(false);
-        return;
-      }
+  const isAdmin = useMemo(() => {
+    if (!user?.email) return false;
+    const allowlist = buildAdminAllowlist();
+    return allowlist.has(user.email.toLowerCase());
+  }, [user?.email]);
 
-      const email = firebaseUser.email?.toLowerCase() || "";
-      const allowed =
-        ADMIN_EMAILS.length === 0 ? true : ADMIN_EMAILS.includes(email);
-
-      setUser(firebaseUser);
-      setIsAdmin(allowed);
-      setLoading(false);
-    });
-
-    return () => unsub();
-  }, []);
-
-  return { user, isAdmin, loading };
+  return { user, isAdmin, loading: !authReady };
 }


### PR DESCRIPTION
## Summary
- centralize admin allowlist parsing and useAuth checks so all admin guards share the same source of truth
- route all admin subsections through the dashboard shell (including payments) and redirect legacy admin paths into /admin with an initial view
- switch admin auth page navigation to SPA Link and keep sidebar navigation in-app without hard reloads

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938eec7a588832cb377e33ee5f47f5e)