### PR TITLE
Fix auth gating and unify booking payment normalization

### DIFF
--- a/src/lib/bookings.js
+++ b/src/lib/bookings.js
@@ -130,3 +130,71 @@ export function normalizeBookingForRead(docData) {
   
   return result;
 }
+
+/**
+ * Normalize payment-related fields across legacy booking schemas.
+ * Ensures consistent totals and paid/deposit math between pages.
+ */
+export function getBookingPaymentSummary(booking) {
+  const totalAmount = Number(
+    booking?.totalAmount ??
+      booking?.payment?.totalAmount ??
+      booking?.totalPrice ??
+      booking?.total ??
+      booking?.cost ??
+      0
+  );
+
+  const amountPaid = Number(
+    booking?.amountPaid ??
+      booking?.payment?.amountPaid ??
+      booking?.paid ??
+      0
+  );
+
+  const depositAmount = Number(
+    booking?.depositAmount ??
+      booking?.payment?.depositAmount ??
+      booking?.depositDue ??
+      0
+  );
+
+  const depositPaid = Boolean(
+    booking?.depositPaid ??
+      booking?.payment?.depositPaid ??
+      booking?.depositReceived ??
+      false
+  );
+
+  const refundedAmount = Number(
+    booking?.refundedAmount ??
+      booking?.payment?.refundedAmount ??
+      0
+  );
+
+  const refunded = Boolean(
+    booking?.refunded ??
+      booking?.payment?.refunded ??
+      refundedAmount > 0
+  );
+
+  const status = String(booking?.status || "").toLowerCase();
+  const isCancelled = status === "cancelled" || status === "canceled";
+
+  const effectivePaid = amountPaid + (depositPaid ? depositAmount : 0);
+  const remaining = (isCancelled || refunded)
+    ? 0
+    : Math.max(totalAmount - effectivePaid, 0);
+
+  return {
+    totalAmount,
+    amountPaid,
+    depositAmount,
+    depositPaid,
+    refunded,
+    refundedAmount,
+    effectivePaid,
+    remaining,
+    isCancelled,
+  };
+}

--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -14,6 +14,23 @@ const firebaseConfig = {
 };
 
 const app = initializeApp(firebaseConfig);
+
+const requiredEnvKeys = [
+  "VITE_FIREBASE_API_KEY",
+  "VITE_FIREBASE_AUTH_DOMAIN",
+  "VITE_FIREBASE_PROJECT_ID",
+  "VITE_FIREBASE_STORAGE_BUCKET",
+  "VITE_FIREBASE_MESSAGING_SENDER_ID",
+  "VITE_FIREBASE_APP_ID",
+];
+
+const missingEnvKeys = requiredEnvKeys.filter(
+  (key) => !import.meta.env[key]
+);
+
+if (missingEnvKeys.length > 0) {
+  console.warn("[firebase] Missing env vars:", missingEnvKeys);
+}
 try {
   const app = getApp();
   console.log("[ENV CHECK] hostname:", window.location.hostname);
@@ -25,13 +42,16 @@ try {
 
 const auth = getAuth(app);
 const db = getFirestore(app);
-const functions = getFunctions(app);
+const functionsRegion = import.meta.env.VITE_FIREBASE_FUNCTIONS_REGION;
+const functions = functionsRegion
+  ? getFunctions(app, functionsRegion)
+  : getFunctions(app);
 
 if (process.env.NODE_ENV !== "production") {
   console.info("[firebase] config", {
     projectId: firebaseConfig.projectId,
     authDomain: firebaseConfig.authDomain,
-    functionsRegion: functions?.region || "default",
+    functionsRegion: functionsRegion || functions?.region || "default",
   });
 }
 

--- a/src/pages/ClientPortalPage.jsx
+++ b/src/pages/ClientPortalPage.jsx
@@ -67,7 +67,11 @@ import {
 // Firestore helpers
 import { ensureProfile, getAddress } from "@/lib/db";
 import { updateProfileContact, updateProfileAddress, upsertProfile } from "@/lib/profileModel";
-import { normalizeBookingForRead, normalizeBookingForWrite } from "@/lib/bookings";
+import {
+  getBookingPaymentSummary,
+  normalizeBookingForRead,
+  normalizeBookingForWrite,
+} from "@/lib/bookings";
 import {
   buildUserBookingQueries,
   claimGuestBookings,
@@ -515,36 +519,11 @@ const bookingsWithFriendly = useMemo(() => {
     const endAt = r.endAt ?? null;
     const createdAt = r.createdAt ?? null;
 
-    // Normalize totals
-    const total = Number(
-      r.totalAmount ??
-        r.payment?.totalAmount ??
-        r.total ??
-        r.cost ??
-        0
-    );
-
-    const paid = Number(
-      r.amountPaid ??
-        r.payment?.amountPaid ??
-        r.paid ??
-        0
-    );
-
-    // Normalize deposit fields (from admin edits OR legacy)
-    const depositAmount = Number(
-      r.depositAmount ??
-        r.payment?.depositAmount ??
-        r.depositDue ??
-        0
-    );
-
-    const depositPaid = Boolean(
-      r.depositPaid ??
-        r.payment?.depositPaid ??
-        r.depositReceived ??
-        false
-    );
+    const paymentSummary = getBookingPaymentSummary(r);
+    const total = paymentSummary.totalAmount;
+    const paid = paymentSummary.amountPaid;
+    const depositAmount = paymentSummary.depositAmount;
+    const depositPaid = paymentSummary.depositPaid;
 
     return {
       id: r.id,

--- a/src/pages/PaymentCenterPage.jsx
+++ b/src/pages/PaymentCenterPage.jsx
@@ -20,9 +20,10 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 
-import { db, auth, functions } from "@/lib/firebase";
-import { normalizeBookingForRead } from "@/lib/bookings";
-import { collection, doc, getDoc, onSnapshot, query, where } from "firebase/firestore";
+import { db, functions } from "@/lib/firebase";
+import { getBookingPaymentSummary, normalizeBookingForRead } from "@/lib/bookings";
+import { useAuth } from "@/context/AuthContext";
+import { collection, onSnapshot, query, where } from "firebase/firestore";
 import { httpsCallable } from "firebase/functions";
 
 import logoPrimary from "@/assets/logo/logo-primary.png";
@@ -34,12 +35,6 @@ function toDate(tsLike) {
   if (tsLike instanceof Date) return tsLike;
   const d = new Date(tsLike);
   return Number.isNaN(d.getTime()) ? null : d;
-}
-
-function normalizePhone(raw) {
-  const digits = String(raw || "").replace(/\D+/g, "");
-  if (digits.length === 11 && digits.startsWith("1")) return digits.slice(1);
-  return digits || null;
 }
 
 function dedupeById(rows) {
@@ -137,54 +132,18 @@ function prettifyMethodLabel(methodRaw) {
  * - remaining = max(total - effectivePaid, 0)
  */
 function computeBookingMoney(b) {
-  if (!b) {
-    return {
-      totalPrice: 0,
-      depositAmount: 0,
-      depositPaid: false,
-      basePaid: 0,
-      effectivePaid: 0,
-      remaining: 0,
-      refunded: false,
-      refundedAmount: 0,
-    };
-  }
-
-  const totalPrice =
-    b.totalPrice != null
-      ? Number(b.totalPrice)
-      : b.cost != null
-      ? Number(b.cost)
-      : 0;
-
-  const depositAmount = Number(b.depositAmount || 0);
-  const depositPaid = !!b.depositPaid;
-
-  // Non-deposit payment portion (what admin stores as amountPaid)
-  const basePaid = Number(b.amountPaid ?? b.paid ?? 0);
-
-  const refundedAmount = Number(b.refundedAmount || 0);
-  const refunded = !!b.refunded || refundedAmount > 0;
-
-  // How much actually counts toward clearing the total
-  const effectivePaid = basePaid + (depositPaid ? depositAmount : 0);
-
-  // Detect cancellation (both spellings)
-  const status = String(b.status || "").toLowerCase();
-  const isCancelled = status === "cancelled" 
-
-  // Cancelled or refunded bookings have no remaining balance
-  const remaining = (isCancelled || refunded) ? 0 : Math.max(totalPrice - effectivePaid, 0);
+  const summary = getBookingPaymentSummary(b);
 
   return {
-    totalPrice,
-    depositAmount,
-    depositPaid,
-    basePaid,
-    effectivePaid,
-    remaining,
-    refunded,
-    refundedAmount,
+    totalPrice: summary.totalAmount,
+    depositAmount: summary.depositAmount,
+    depositPaid: summary.depositPaid,
+    basePaid: summary.amountPaid,
+    effectivePaid: summary.effectivePaid,
+    remaining: summary.remaining,
+    refunded: summary.refunded,
+    refundedAmount: summary.refundedAmount,
+    isCancelled: summary.isCancelled,
   };
 }
 
@@ -225,13 +184,10 @@ function derivePaymentInfo(b) {
     remaining,
     refunded,
     refundedAmount,
+    isCancelled,
   } = computeBookingMoney(b);
 
   const anyPayment = depositPaid || basePaid > 0;
-
-  // Detect cancellation for payment status label
-  const status = String(b.status || "").toLowerCase();
-  const isCancelled = status === "cancelled" 
 
   let paymentStatus = "Unpaid";
   if (refunded) {
@@ -617,6 +573,7 @@ function buildInvoiceLineItems(booking, info, addressOverride) {
 
 const PaymentCenterPage = () => {
   const navigate = useNavigate();
+  const { user, authReady } = useAuth();
   const [bookings, setBookings] = useState([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(null);
@@ -669,63 +626,68 @@ const PaymentCenterPage = () => {
       setLoadError(null);
     };
 
-    const run = async () => {
-      const user = auth.currentUser;
-      if (!user) {
+    if (!authReady) {
+      setLoading(true);
+      return () => {};
+    }
+
+    if (!user) {
+      setLoading(false);
+      setBookings([]);
+      setLoadError(null);
+      return () => {};
+    }
+
+    setLoading(true);
+
+    const bookingsRef = collection(db, "bookings");
+    const qUid = query(bookingsRef, where("userId", "==", user.uid));
+
+    const unsubUid = onSnapshot(
+      qUid,
+      (snap) => {
+        const rows = snap.docs.map((d) =>
+          normalizeBookingForRead({ id: d.id, ...d.data() })
+        );
+        mergeBookingsFromSource(rows, "uid");
+      },
+      (err) => {
+        const isPermissionDenied = err?.code === "permission-denied";
+
+        if (isPermissionDenied) {
+          // Permission-denied should NOT occur for uid queries (client owns their data).
+          console.warn(
+            "[payment-center] Permission denied on uid query (unexpected)",
+            { code: err?.code, message: err?.message }
+          );
+        } else {
+          console.error("[payment-center] uid query error", {
+            code: err?.code,
+            message: err?.message,
+            queryType: "uid",
+          });
+        }
+
+        setLoadError(err?.message || String(err));
         setLoading(false);
-        setBookings([]);
-        return;
-      }
 
-      const bookingsRef = collection(db, "bookings");
-      const qUid = query(bookingsRef, where("userId", "==", user.uid));
-
-      const unsubUid = onSnapshot(
-        qUid,
-        (snap) => {
-          const rows = snap.docs.map((d) => normalizeBookingForRead({ id: d.id, ...d.data() }));
-          mergeBookingsFromSource(rows, "uid");
-        },
-        (err) => {
-          const isPermissionDenied = err?.code === "permission-denied";
-          
-          if (isPermissionDenied) {
-            // Permission-denied should NOT occur for uid queries (client owns their data).
-            console.warn(
-              "[payment-center] Permission denied on uid query (unexpected)",
-              { code: err?.code, message: err?.message }
-            );
-          } else {
-            console.error("[payment-center] uid query error", {
-              code: err?.code,
-              message: err?.message,
-              queryType: "uid",
-            });
-          }
-          
-          setLoadError(err?.message || String(err));
-          setLoading(false);
-          
-          if (process.env.NODE_ENV !== "production") {
-            const errorCode = err?.code || "";
-            if (errorCode === "permission-denied" || errorCode === "failed-precondition") {
-              setFirestoreErrors((prev) => [
-                ...prev,
-                { queryType: "uid", code: errorCode, message: err?.message || String(err) },
-              ]);
-            }
+        if (process.env.NODE_ENV !== "production") {
+          const errorCode = err?.code || "";
+          if (errorCode === "permission-denied" || errorCode === "failed-precondition") {
+            setFirestoreErrors((prev) => [
+              ...prev,
+              { queryType: "uid", code: errorCode, message: err?.message || String(err) },
+            ]);
           }
         }
-      );
-      unsubs.push(unsubUid);
+      }
+    );
+    unsubs.push(unsubUid);
 
-      // NOTE: For client users, we only query by userId (uid query above).
-      // Email and phone-based queries are blocked by Firestore rules for non-admin users.
-      // Admin users should use admin pages (AdminPaymentsPage) which has email/phone fallbacks.
-      // This prevents permission-denied errors in client PaymentCenter.
-    };
-
-    run();
+    // NOTE: For client users, we only query by userId (uid query above).
+    // Email and phone-based queries are blocked by Firestore rules for non-admin users.
+    // Admin users should use admin pages (AdminPaymentsPage) which has email/phone fallbacks.
+    // This prevents permission-denied errors in client PaymentCenter.
 
     return () => {
       isActive = false;
@@ -735,7 +697,7 @@ const PaymentCenterPage = () => {
         } catch {}
       });
     };
-  }, []);
+  }, [authReady, user]);
 
   const now = new Date();
 
@@ -754,9 +716,10 @@ const PaymentCenterPage = () => {
       if (!start || start >= now) return false;
 
       const status = String(b.status || "").toLowerCase();
-      const depositPaid = !!b.depositPaid;
-      const paid = Number(b.paid || 0);
-      const refunded = !!b.refunded || Number(b.refundedAmount || 0) > 0;
+      const paymentSummary = getBookingPaymentSummary(b);
+      const depositPaid = paymentSummary.depositPaid;
+      const paid = paymentSummary.amountPaid;
+      const refunded = paymentSummary.refunded;
 
       const anyPayment = depositPaid || paid > 0 || refunded;
       const doneStatus =
@@ -886,8 +849,6 @@ const PaymentCenterPage = () => {
     );
   };
 
-  const user = auth.currentUser;
-
   const { nextUpcoming, totalDueNow } = summary;
 
   const nextStart = nextUpcoming
@@ -933,9 +894,7 @@ const PaymentCenterPage = () => {
       return;
     }
 
-    const user = auth.currentUser;
-
-    if (!user) {
+    if (!user || !authReady) {
       setPayError("You need to be signed in to pay your balance online.");
       return;
     }
@@ -1080,6 +1039,7 @@ const PaymentCenterPage = () => {
       if (!win) return;
 
       const orderCode = booking.orderCode || booking.id?.slice(0, 8) || "";
+      const logoUrl = new URL(logoPrimary, window.location.origin).toString();
 
       const invoiceDate = new Date().toLocaleDateString(undefined, {
         month: "short",
@@ -1154,7 +1114,7 @@ const PaymentCenterPage = () => {
               <div style="display:flex; justify-content:space-between; align-items:flex-start; margin-bottom:28px;">
                 <div style="display:flex; align-items:center; gap:12px;">
                   <div style="width:40px; height:40px; border-radius:999px; overflow:hidden; display:flex; align-items:center; justify-content:center; border:1px solid #f1d7ff;">
-                    <img src="${logoPrimary}" alt="Sanchez Services" style="max-width:100%; max-height:100%; object-fit:contain;" />
+                    <img src="${logoUrl}" alt="Sanchez Services" style="max-width:100%; max-height:100%; object-fit:contain;" />
                   </div>
                   <div>
                     <div style="font-size:14px; font-weight:600; letter-spacing:0.14em; text-transform:uppercase; color:#7e4b8e;">Sanchez Services</div>
@@ -1379,7 +1339,7 @@ const PaymentCenterPage = () => {
         )}
 
         {/* Summary: next appointment + amount due now */}
-        {user && (
+        {user && authReady && (
           <Card className="bg-white border-plum/10 shadow-sm">
             <CardContent className="py-3 sm:py-4 md:py-5">
               <div className="grid gap-4 sm:gap-5 md:gap-6 md:grid-cols-2 items-center">
@@ -1453,7 +1413,7 @@ const PaymentCenterPage = () => {
         )}
 
         {/* If not signed in, show gate and stop */}
-        {!user && (
+        {!user && authReady && (
           <Card className="bg-white border-plum/10 shadow-sm">
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-plum">
@@ -1476,7 +1436,7 @@ const PaymentCenterPage = () => {
           </Card>
         )}
 
-        {user && (
+        {user && authReady && (
           <>
             {/* Top row: upcoming + billing side by side */}
             <div className="grid gap-4 md:grid-cols-2">


### PR DESCRIPTION
### Motivation
- Production showed auth race conditions and empty Payment Center lists because queries ran before Firebase auth fully initialized. 
- Client Portal and Payment Center computed payment totals from different schema shapes, causing production-only 0/NaN displays due to schema drift. 
- Firebase runtime/function configuration and asset URL handling were fragile in production (missing env keys, function region assumptions, and relative asset injection into `window.open` HTML). 
- The goal was to restore dev/prod parity by unifying booking math, gating queries on auth readiness, and hardening runtime config and printable invoice asset resolution. 

### Description
- Added `getBookingPaymentSummary` in `src/lib/bookings.js` and switched both `src/pages/ClientPortalPage.jsx` and `src/pages/PaymentCenterPage.jsx` to use it so totals, paid, deposit and refund math are consistent across pages. 
- Reworked `PaymentCenterPage` to use the app `useAuth()` (`src/context/AuthContext.jsx`) and to wait for `authReady`/`user` before subscribing to Firestore, preventing production auth race conditions. 
- Hardened `src/lib/firebase.js` by warning on missing `VITE_FIREBASE_*` env vars and supporting an optional `VITE_FIREBASE_FUNCTIONS_REGION` when calling `getFunctions`. 
- Made invoice print HTML robust by resolving `logoPrimary` to an absolute URL before injecting into `window.open` content, and removed a few unsafe direct `auth.currentUser` reads in favor of `useAuth` checks. 

### Testing
- No automated tests were run as part of this change; CI was not executed by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951d872fe70832c8c5d605893049efb)